### PR TITLE
Support for both Laravel 5.6 and 5.5

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -23,6 +23,7 @@ class NewCommand extends Command
             ->setDescription('Create a new Craftable application.')
             ->addArgument('name', InputArgument::OPTIONAL)
             ->addOption('dev', null, InputOption::VALUE_NONE, 'Installs the latest DEV release ready for Craftable development')
+            ->addOption('lts', null, InputOption::VALUE_NONE, 'Installs Craftable using LTS release of Laravel (currently v5.5)')
             ->addOption('no-install', null, InputOption::VALUE_NONE, 'Do not run craftable:install')
             ;
     }
@@ -42,28 +43,28 @@ class NewCommand extends Command
 
         $directory = "\"".$input->getArgument('name')."\"";
 
-        array_push($commands, $composer.' create-project --prefer-dist laravel/laravel '.$directory.' "5.5.*" ');
+        array_push($commands, $composer.' create-project --prefer-dist laravel/laravel '.$directory.($input->getOption('lts') ? ' "5.5.*" ' : ' "5.6.*" '));
 
         array_push($commands, 'cd '.$directory);
 
         $output->writeln('<info>Crafting Craftable :) ...</info>');
 
         $packages = [
-            "brackets/admin-ui",
-            "brackets/admin-listing",
-            "brackets/admin-auth",
-            "brackets/admin-translations",
-            "brackets/media",
-            "brackets/translatable",
+            "brackets/admin-ui:dev-laravel-56 as 2.0.x-dev",
+            "brackets/admin-listing:dev-laravel-56 as 2.0.x-dev",
+            "brackets/admin-auth:dev-laravel-56 as 2.0.x-dev",
+            "brackets/admin-translations:dev-laravel-56 as 2.0.x-dev",
+            "brackets/media:dev-laravel-56 as 1.0.x-dev",
+            "brackets/translatable:dev-laravel-56 as 1.0.x-dev",
             "brackets/craftable",
         ];
 
         if ($input->getOption('dev')) {
             $packages = array_map(function($package) {
-                return '"'.$package.':dev-master"';
+                return '"'.$package.'"';
             }, $packages);
             array_push($commands, $composer.' require '.implode(' ', $packages));
-            array_push($commands, $composer.' require --dev "brackets/admin-generator:dev-master"');
+            array_push($commands, $composer.' require --dev "brackets/admin-generator:dev-laravel-56 as 2.0.x-dev"');
             array_push($commands, 'rm -rf vendor/brackets');
             array_push($commands, $composer.' update --prefer-source');
         } else {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -50,21 +50,21 @@ class NewCommand extends Command
         $output->writeln('<info>Crafting Craftable :) ...</info>');
 
         $packages = [
-            "brackets/admin-ui:dev-laravel-56 as 2.0.x-dev",
-            "brackets/admin-listing:dev-laravel-56 as 2.0.x-dev",
-            "brackets/admin-auth:dev-laravel-56 as 2.0.x-dev",
-            "brackets/admin-translations:dev-laravel-56 as 2.0.x-dev",
-            "brackets/media:dev-laravel-56 as 1.0.x-dev",
-            "brackets/translatable:dev-laravel-56 as 1.0.x-dev",
+            "brackets/admin-ui",
+            "brackets/admin-listing",
+            "brackets/admin-auth",
+            "brackets/admin-translations",
+            "brackets/media",
+            "brackets/translatable",
             "brackets/craftable",
         ];
 
         if ($input->getOption('dev')) {
             $packages = array_map(function($package) {
-                return '"'.$package.'"';
+                return '"'.$package.':dev-master"';
             }, $packages);
             array_push($commands, $composer.' require '.implode(' ', $packages));
-            array_push($commands, $composer.' require --dev "brackets/admin-generator:dev-laravel-56 as 2.0.x-dev"');
+            array_push($commands, $composer.' require --dev "brackets/admin-generator:dev-master"');
             array_push($commands, 'rm -rf vendor/brackets');
             array_push($commands, $composer.' update --prefer-source');
         } else {


### PR DESCRIPTION
V tomto PR som pridal do installera option na instalaciu laravelu 5.5 a 5.6.

Idealne by bolo, ak by ste pozreli aj vsetky ostatne packages, pre ktore som tiez urobil rovnomennu branch (ale nechce sa mi robit tolko PR). Cize prosim vedzte, ze approvnutim tohto PR approvujete aj vsetky hentie :)

Poznamka: Vsetky zmeny v tomto subore od riadku 50 rollbackneme. Momentalne su tam len preto, aby sa to cele dalo testovat. Cize ked mi to schvalite, ja este doplnim jeden commit, v ktorom to vratim a nasledne vsetky packages mergnem a spravim nove releasy.

Kedze zmena je spatne kompatibilna, tak budeme robit len minor version. Cize na existujucom projekte kludne dat update. A v pripade, ze by ste chceli upgradnut z 5.5 na 5.6, tak staci naozaj len zmenit composer.json a nasledne postupovat podla Upgrade guide ku Laravelu a that's it. U nas ziadne zmeny.

Po mergi by som este updatol dokumentaciu a nasledne odpisal na issue na githube.